### PR TITLE
Fix error handling in rpc-request

### DIFF
--- a/src/websockets/wamp/WAMPClient.ts
+++ b/src/websockets/wamp/WAMPClient.ts
@@ -9,12 +9,15 @@ export class WAMPClient {
     public static registerWAMP(socket): void {
         socket.call = (procedure, data) => new Promise((resolve, reject) => {
             socket.emit('rpc-request', {type: '/RPCRequest', procedure, data}, (err, result) => {
-                if (result) {
-                    resolve(result.data);
-                } else if (err) {
-                    reject(err)
+                if (err) {
+                    reject(err);
+                } else {
+                    if (result) {
+                        resolve(result.data);
+                    } else  {
+                        resolve();
+                    }
                 }
-                resolve();
             });
         })
     }


### PR DESCRIPTION
Before, we got success messages with

> { type: '/RPCRequest', procedure: 'status', data: undefined }

instead of response objects because `err` and `result` had been set.

Those cases now correctly result in

> [winston] Attempt to write logs with no transports {"message":"could not update status of 11.22.33.44:7001: TimeoutError: Event response for 'rpc-request' timed out","level":"warn"}