### PR TITLE
Use a separate build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,6 @@
-
-# Ignore Node & Bower
+# NPM
 ###################
-node_modules
-bower_components
-build
-.tmp
-package-lock.json
-src/**/*.map
-src/**/*.js
+node_modules/
 
 # Ignore Test reporters
 ###################

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 ###################
 node_modules/
 
+# TypeScript compilation output
+build/
+
 # Ignore Test reporters
 ###################
 **/test/coverage

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write './src/**/*.ts'",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "start": "yarn build && node src/main.js 5001"
+    "start": "yarn build && node build/main.js 5001"
   },
   "author": "Hendrik Hofstadt & Lisk Builders",
   "license": "MIT",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { BlockchainManager } from "./blocks/BlockchainManager";
 import * as crypto from "crypto";
 import { NotificationManager } from "./notifications/NotificationManager";
 
-const config = require("./config.json");
+const config = require("../src/config.json");
 
 const nonce =
   "monitoring_" +

--- a/src/notifications/NotificationManager.ts
+++ b/src/notifications/NotificationManager.ts
@@ -5,7 +5,7 @@ import { DelegateDetails } from "../peers/LiskClient";
 import { RocketChatAdapter } from "./rocket/adapter";
 import { TelegramAdapter } from "./telegram/adapter";
 
-const config = require("../config.json");
+const config = require("../../src/config.json");
 
 export class NotificationManager {
   private adapters: NotificationAdapter[] = [];

--- a/src/peers/PeerManager.ts
+++ b/src/peers/PeerManager.ts
@@ -5,7 +5,7 @@ import * as semver from "semver";
 import { SocketServer } from "../websockets/SocketServer";
 import { PeerInfo } from "./LiskClient";
 
-const config = require("../config.json");
+const config = require("../../src/config.json");
 
 /***
  * PeerManager keeps track of connected peers.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "strictNullChecks": true,
     "target": "es2015",
     "module": "commonjs",
-    "sourceMap": true
+    "sourceMap": true,
+    "outDir": "build",
   }
 }


### PR DESCRIPTION
This makes navigating source files much easier during development.

Additionally it simplifies checking-in pure .js files because they will not be ignored by default