### PR TITLE
Extract HTTP API

### DIFF
--- a/src/blocks/BlockchainManager.ts
+++ b/src/blocks/BlockchainManager.ts
@@ -47,9 +47,9 @@ export class BlockchainManager extends EventEmitter {
     let chain = new Chain();
 
     return new Promise((resolve, reject) => {
-      peer.client
-        .getBlocksHTTP()
-        .then(blocks => chain.updateBlocks(blocks))
+      peer.client.http
+        .getBlocks()
+        .then(response => chain.updateBlocks(response.data))
         .then(onChain => {
           this._chains.push(chain);
           resolve();

--- a/src/blocks/Chain.ts
+++ b/src/blocks/Chain.ts
@@ -1,5 +1,6 @@
 import * as crypto from "crypto";
-import { Block, NodeStatus } from "../peers/LiskClient";
+import { NodeStatus } from "../peers/LiskClient";
+import { Block } from "../lib/HttpApi";
 
 /***
  * Chain represents a chain on the Lisk network

--- a/src/delegates/DelegateMonitor.ts
+++ b/src/delegates/DelegateMonitor.ts
@@ -98,7 +98,7 @@ export class DelegateMonitor extends events.EventEmitter {
     return this.peerManager
       .getBestHTTPPeer()
       .client.getForgersHTTP()
-      .then(data => this.processForgers(data.data, data.meta));
+      .then(response => this.processForgers(response.data, response.meta));
   }
 
   /***

--- a/src/delegates/DelegateMonitor.ts
+++ b/src/delegates/DelegateMonitor.ts
@@ -2,7 +2,7 @@ import { PeerManager } from "../peers/PeerManager";
 import * as events from "events";
 import * as _ from "underscore";
 import * as log from "winston";
-import { Block, DelegateDetails, ForgerDetail, ForgerMeta } from "../peers/LiskClient";
+import { Block, DelegateDetails, ForgerDetail, ForgerMeta } from "../lib/HttpApi";
 
 /***
  * The DelegateMonitor keeps track of the delegate ranks and forging status of delegates on a Lisk chain
@@ -97,7 +97,7 @@ export class DelegateMonitor extends events.EventEmitter {
   private updateForgers(): Promise<void> {
     return this.peerManager
       .getBestHTTPPeer()
-      .client.getForgersHTTP()
+      .client.http.getForgers()
       .then(response => this.processForgers(response.data, response.meta));
   }
 
@@ -149,8 +149,8 @@ export class DelegateMonitor extends events.EventEmitter {
   private updateBlocks(): Promise<void> {
     return this.peerManager
       .getBestHTTPPeer()
-      .client.getBlocksHTTP()
-      .then(blocks => this.processBlocks(blocks));
+      .client.http.getBlocks()
+      .then(response => this.processBlocks(response.data));
   }
 
   /***
@@ -174,7 +174,7 @@ export class DelegateMonitor extends events.EventEmitter {
       if (delegate.details && delegate.details.producedBlocks > 0 && !delegate.lastBlock) {
         delegate.lastBlock = await this.peerManager
           .getBestHTTPPeer()
-          .client.getLastBlockByDelegateHTTP(delegate.details.account.publicKey);
+          .client.http.getLastBlockByDelegate(delegate.details.account.publicKey);
       }
     }
   }
@@ -186,8 +186,8 @@ export class DelegateMonitor extends events.EventEmitter {
   private updateDelegates(): Promise<void> {
     return this.peerManager
       .getBestHTTPPeer()
-      .client.getDelegatesHTTP()
-      .then(data => this.processDelegates(data));
+      .client.http.getDelegates()
+      .then(response => this.processDelegates(response.data));
   }
 
   /***

--- a/src/lib/HttpApi.ts
+++ b/src/lib/HttpApi.ts
@@ -1,0 +1,142 @@
+import * as request from "request-promise-native";
+
+// Lisk HTTP API
+// https://app.swaggerhub.com/apis/LiskHQ/Lisk
+export class HttpApi {
+  constructor(
+    protected readonly hostname: string,
+    protected readonly port: number,
+    protected readonly secure: boolean = false,
+  ) {}
+
+  public getNodeStatus(): Promise<ResponseObject<NodeStatusExtended>> {
+    return request(`${this.baseUrl()}/node/status`, {
+      json: true,
+    });
+  }
+
+  public getBlocks(): Promise<ResponseList<Block>> {
+    return request(
+      `${this.baseUrl()}/blocks?limit=100`,
+      { json: true },
+    );
+  }
+
+  public getForgers(): Promise<ForgerResponse> {
+    return request(
+      `${this.baseUrl()}/delegates/forgers?limit=100`,
+      { json: true },
+    );
+  }
+
+  public getDelegates(): Promise<ResponseList<DelegateDetails>> {
+    return request(
+      `${this.baseUrl()}/delegates?limit=101&sort=rank:asc`,
+      { json: true },
+    );
+  }
+
+  public getLastBlockByDelegate(generatorKey: string): Promise<Block> {
+    return request(
+      `${this.baseUrl()}/blocks?limit=1&generatorPublicKey=${generatorKey}`,
+      { json: true },
+    ).then(data => data.data[0]);
+  }
+
+  public getBlockByHeight(height: number): Promise<Block> {
+    return request(
+      `${this.baseUrl()}/blocks?limit=1&height=${height}`,
+    ).then(data => data.data[0]);
+  }
+
+  // method is proteced to allow adding endpoints by subclassing
+  protected baseUrl(): string {
+    const protocol = this.secure ? "https" : "http";
+    return `${protocol}://${this.hostname}:${this.port}/api`;
+  }
+}
+
+export interface Block {
+  readonly id: string;
+  readonly version: number;
+  readonly timestamp: number;
+  readonly height: number;
+  readonly numberOfTransactions: number;
+  readonly totalAmount: string;
+  readonly totalFee: string;
+  readonly reward: string;
+  readonly payloadLength: number;
+  readonly payloadHash: string;
+  readonly generatorPublicKey: string;
+  readonly blockSignature: string;
+  readonly confirmations: number;
+  readonly totalForged: string;
+  readonly generatorAddress: string;
+  readonly previousBlockId: string;
+}
+
+export interface TransactionsStats {
+  readonly confirmed: number;
+  readonly unconfirmed: number;
+  readonly unprocessed: number;
+  readonly unsigned: number;
+  readonly total: number;
+}
+
+export interface NodeStatusExtended {
+  readonly broadhash: string;
+  readonly consensus: number;
+  readonly height: number;
+  readonly loaded: boolean;
+  readonly networkHeight: number;
+  readonly syncing: boolean;
+  readonly transactions: TransactionsStats;
+}
+
+export interface ForgerMeta {
+  readonly lastBlock: number;
+  readonly lastBlockSlot: number;
+  readonly currentSlot: number;
+  readonly limit: number;
+  readonly offset: number;
+}
+
+export interface ForgerDetail {
+  readonly publicKey: string;
+  readonly username: string;
+  readonly address: string;
+  readonly nextSlot: number;
+}
+
+export interface ForgerResponse {
+  readonly meta: ForgerMeta;
+  readonly data: ForgerDetail[];
+}
+
+export interface Account {
+  readonly address: string;
+  readonly publicKey: string;
+  readonly secondPublicKey: string;
+};
+
+export type DelegateDetails = {
+  readonly rewards: string;
+  readonly vote: string;
+  readonly producedBlocks: number;
+  readonly missedBlocks: number;
+  readonly username: string;
+  readonly rank: number;
+  readonly approval: number;
+  readonly productivity: number;
+  readonly account: Account;
+};
+
+export interface ResponseObject<T> {
+  readonly meta: any;
+  readonly data: T;
+}
+
+export interface ResponseList<T> {
+  readonly meta: any;
+  readonly data: T[];
+}

--- a/src/lib/HttpApi.ts
+++ b/src/lib/HttpApi.ts
@@ -10,29 +10,33 @@ export class HttpApi {
   ) {}
 
   public getNodeStatus(): Promise<ResponseObject<NodeStatusExtended>> {
-    return request(`${this.baseUrl()}/node/status`, { json: true });
+    return request(`${this.baseUrl()}/node/status`, { json: true }).promise();
   }
 
   public getBlocks(): Promise<ResponseList<Block>> {
-    return request(`${this.baseUrl()}/blocks?limit=100`, { json: true });
+    return request(`${this.baseUrl()}/blocks?limit=100`, { json: true }).promise();
   }
 
   public getForgers(): Promise<ForgerResponse> {
-    return request(`${this.baseUrl()}/delegates/forgers?limit=100`, { json: true });
+    return request(`${this.baseUrl()}/delegates/forgers?limit=100`, { json: true }).promise();
   }
 
   public getDelegates(): Promise<ResponseList<DelegateDetails>> {
-    return request(`${this.baseUrl()}/delegates?limit=101&sort=rank:asc`, { json: true });
+    return request(`${this.baseUrl()}/delegates?limit=101&sort=rank:asc`, { json: true }).promise();
   }
 
   public getLastBlockByDelegate(generatorKey: string): Promise<Block> {
     return request(`${this.baseUrl()}/blocks?limit=1&generatorPublicKey=${generatorKey}`, {
       json: true,
-    }).then(data => data.data[0]);
+    })
+      .promise()
+      .then(data => data.data[0]);
   }
 
   public getBlockByHeight(height: number): Promise<Block> {
-    return request(`${this.baseUrl()}/blocks?limit=1&height=${height}`).then(data => data.data[0]);
+    return request(`${this.baseUrl()}/blocks?limit=1&height=${height}`)
+      .promise()
+      .then(data => data.data[0]);
   }
 
   // method is proteced to allow adding endpoints by subclassing

--- a/src/lib/HttpApi.ts
+++ b/src/lib/HttpApi.ts
@@ -10,43 +10,29 @@ export class HttpApi {
   ) {}
 
   public getNodeStatus(): Promise<ResponseObject<NodeStatusExtended>> {
-    return request(`${this.baseUrl()}/node/status`, {
-      json: true,
-    });
+    return request(`${this.baseUrl()}/node/status`, { json: true });
   }
 
   public getBlocks(): Promise<ResponseList<Block>> {
-    return request(
-      `${this.baseUrl()}/blocks?limit=100`,
-      { json: true },
-    );
+    return request(`${this.baseUrl()}/blocks?limit=100`, { json: true });
   }
 
   public getForgers(): Promise<ForgerResponse> {
-    return request(
-      `${this.baseUrl()}/delegates/forgers?limit=100`,
-      { json: true },
-    );
+    return request(`${this.baseUrl()}/delegates/forgers?limit=100`, { json: true });
   }
 
   public getDelegates(): Promise<ResponseList<DelegateDetails>> {
-    return request(
-      `${this.baseUrl()}/delegates?limit=101&sort=rank:asc`,
-      { json: true },
-    );
+    return request(`${this.baseUrl()}/delegates?limit=101&sort=rank:asc`, { json: true });
   }
 
   public getLastBlockByDelegate(generatorKey: string): Promise<Block> {
-    return request(
-      `${this.baseUrl()}/blocks?limit=1&generatorPublicKey=${generatorKey}`,
-      { json: true },
-    ).then(data => data.data[0]);
+    return request(`${this.baseUrl()}/blocks?limit=1&generatorPublicKey=${generatorKey}`, {
+      json: true,
+    }).then(data => data.data[0]);
   }
 
   public getBlockByHeight(height: number): Promise<Block> {
-    return request(
-      `${this.baseUrl()}/blocks?limit=1&height=${height}`,
-    ).then(data => data.data[0]);
+    return request(`${this.baseUrl()}/blocks?limit=1&height=${height}`).then(data => data.data[0]);
   }
 
   // method is proteced to allow adding endpoints by subclassing
@@ -117,7 +103,7 @@ export interface Account {
   readonly address: string;
   readonly publicKey: string;
   readonly secondPublicKey: string;
-};
+}
 
 export type DelegateDetails = {
   readonly rewards: string;

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -1,0 +1,3 @@
+# libargus
+
+This is the beginning of a type safe, MIT licensed utility library for Lisk.

--- a/src/notifications/NotificationManager.ts
+++ b/src/notifications/NotificationManager.ts
@@ -1,7 +1,7 @@
 import { Delegate, DelegateMonitor, DelegateStatus } from "../delegates/DelegateMonitor";
 import { BlockchainManager } from "../blocks/BlockchainManager";
 import { PeerManager } from "../peers/PeerManager";
-import { DelegateDetails } from "../peers/LiskClient";
+import { DelegateDetails } from "../lib/HttpApi";
 import { RocketChatAdapter } from "./rocket/adapter";
 import { TelegramAdapter } from "./telegram/adapter";
 

--- a/src/notifications/rocket/adapter.ts
+++ b/src/notifications/rocket/adapter.ts
@@ -2,7 +2,7 @@ import { Delegate, DelegateStatus } from "../../delegates/DelegateMonitor";
 import { convertEpochToSeconds } from "../../utils/generic";
 import { NotificationAdapter } from "../NotificationManager";
 import * as request from "request-promise-native";
-import { DelegateDetails } from "../../peers/LiskClient";
+import { DelegateDetails } from "../../lib/HttpApi";
 
 export class RocketChatAdapter implements NotificationAdapter {
   private authSession;

--- a/src/notifications/telegram/adapter.ts
+++ b/src/notifications/telegram/adapter.ts
@@ -1,6 +1,6 @@
 import { Delegate, DelegateStatus } from "../../delegates/DelegateMonitor";
 import { NotificationAdapter } from "../NotificationManager";
-import { DelegateDetails } from "../../peers/LiskClient";
+import { DelegateDetails } from "../../lib/HttpApi";
 import { RocketChatAdapter } from "../rocket/adapter";
 import { convertEpochToSeconds } from "../../utils/generic";
 

--- a/src/peers/LiskClient.ts
+++ b/src/peers/LiskClient.ts
@@ -1,6 +1,7 @@
 import * as socketCluster from "socketcluster-client";
-import * as request from "request-promise-native";
+
 import { WAMPClient } from "../websockets/wamp/WAMPClient";
+import { HttpApi } from "../lib/HttpApi";
 
 /***
  * LiskClient is a client for the Lisk Core Websocket and HTTP protocol.
@@ -9,6 +10,7 @@ import { WAMPClient } from "../websockets/wamp/WAMPClient";
 export class LiskClient {
   socket: any;
   public peers;
+  public readonly http: HttpApi
 
   public options = {
     hostname: "betanet.lisk.io",
@@ -31,6 +33,7 @@ export class LiskClient {
     this.options.port = wsPort || 5001;
     this.options.httpPort = httpPort || 5000;
     this.options.query = query;
+    this.http = new HttpApi(this.options.hostname, this.options.httpPort);
   }
 
   public connect(
@@ -61,52 +64,6 @@ export class LiskClient {
 
   public getBlocks(lasBlockID?: string): Promise<WSBlockResponse> {
     return this.socket.call("blocks", { lastId: lasBlockID || "" });
-  }
-
-  public getStatusDetailedHTTP(): Promise<NodeStatusExtended> {
-    return request(`http://${this.options.hostname}:${this.options.httpPort}/api/node/status`, {
-      json: true,
-    }).then(data => data.data);
-  }
-
-  public getBlocksHTTP(): Promise<Array<Block>> {
-    return request(
-      `http://${this.options.hostname}:${this.options.httpPort}/api/blocks?limit=100`,
-      { json: true },
-    ).then(data => data.data);
-  }
-
-  public getForgersHTTP(): Promise<ForgerResponse> {
-    return request(
-      `http://${this.options.hostname}:${this.options.httpPort}/api/delegates/forgers?limit=100`,
-      { json: true },
-    ).then(data => data);
-  }
-
-  public getDelegatesHTTP(): Promise<Array<DelegateDetails>> {
-    return request(
-      `http://${this.options.hostname}:${
-        this.options.httpPort
-      }/api/delegates?limit=101&sort=rank:asc`,
-      { json: true },
-    ).then(data => data.data);
-  }
-
-  public getLastBlockByDelegateHTTP(generatorKey: string): Promise<Block> {
-    return request(
-      `http://${this.options.hostname}:${
-        this.options.httpPort
-      }/api/blocks?limit=1&generatorPublicKey=${generatorKey}`,
-      { json: true },
-    ).then(data => data.data[0]);
-  }
-
-  public getBlockByHeight(height: number): Promise<Block> {
-    return request(
-      `http://${this.options.hostname}:${
-        this.options.httpPort
-      }/api/blocks?limit=1&height=${height}`,
-    ).then(data => data.data[0]);
   }
 }
 
@@ -187,78 +144,3 @@ export interface PeerInfo {
   height?: number;
   updated?: any;
 }
-
-export interface Block {
-  id: string;
-  version: number;
-  timestamp: number;
-  height: number;
-  numberOfTransactions: number;
-  totalAmount: string;
-  totalFee: string;
-  reward: string;
-  payloadLength: number;
-  payloadHash: string;
-  generatorPublicKey: string;
-  blockSignature: string;
-  confirmations: number;
-  totalForged: string;
-  generatorAddress: string;
-  previousBlockId: string;
-}
-
-export interface NodeStatusExtended {
-  broadhash: string;
-  consensus: number;
-  height: number;
-  loaded: boolean;
-  networkHeight: number;
-  syncing: boolean;
-  transactions: TransactionsStats;
-}
-
-export interface TransactionsStats {
-  confirmed: number;
-  unconfirmed: number;
-  unprocessed: number;
-  unsigned: number;
-  total: number;
-}
-
-export interface ForgerResponse {
-  meta: ForgerMeta;
-  data: ForgerDetail[];
-}
-
-export interface ForgerMeta {
-  lastBlock: number;
-  lastBlockSlot: number;
-  currentSlot: number;
-  limit: number;
-  offset: number;
-}
-
-export interface ForgerDetail {
-  publicKey: string;
-  username: string;
-  address: string;
-  nextSlot: number;
-}
-
-export type Account = {
-  address: string;
-  publicKey: string;
-  secondPublicKey: string;
-};
-
-export type DelegateDetails = {
-  rewards: string;
-  vote: string;
-  producedBlocks: number;
-  missedBlocks: number;
-  username: string;
-  rank: number;
-  approval: number;
-  productivity: number;
-  account: Account;
-};

--- a/src/peers/LiskClient.ts
+++ b/src/peers/LiskClient.ts
@@ -10,7 +10,7 @@ import { HttpApi } from "../lib/HttpApi";
 export class LiskClient {
   socket: any;
   public peers;
-  public readonly http: HttpApi
+  public readonly http: HttpApi;
 
   public options = {
     hostname: "betanet.lisk.io",

--- a/src/peers/Peer.ts
+++ b/src/peers/Peer.ts
@@ -34,8 +34,8 @@ export class LiskPeer extends events.EventEmitter {
     });
 
     // Check whether client supports HTTP
-    this.client
-      .getStatusDetailedHTTP()
+    this.client.http
+      .getNodeStatus()
       .then(() => (this._httpActive = true))
       .catch(() => {});
 


### PR DESCRIPTION
This makes the HTTP reusable and extensible. It cleans up the LiskClient class.

I moves this in the folder ./lib, which can be the start of reusable components